### PR TITLE
V2023.06.03

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -5,6 +5,8 @@ on:
     branches: [ "main" ]
   push:
     branches: [ "main" ]
+  schedule:
+    - cron: "15 2 * * *" # 2:15am UTC every day
 
 jobs:
   build:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,2 @@
-include naif_eop_historical/earth_720101_070426.bpc
-include naif_eop_historical/earth_720101_070426.md5
+include naif_eop_historical/earth_720101_230601.bpc
+include naif_eop_historical/earth_720101_230601.md5

--- a/README.md
+++ b/README.md
@@ -7,16 +7,16 @@
 [![Build and Test](https://github.com/B612-Asteroid-Institute/naif_eop_historical/actions/workflows/build_test.yml/badge.svg)](https://github.com/B612-Asteroid-Institute/naif_eop_historical/actions/workflows/build_test.yml)
 [![Build, Test, & Publish](https://github.com/B612-Asteroid-Institute/naif_eop_historical/actions/workflows/build_test_publish.yml/badge.svg)](https://github.com/B612-Asteroid-Institute/naif_eop_historical/actions/workflows/build_test_publish.yml)  
 
-This package ships the Navigation and Ancillary Information Facility's high accuracy, historical Earth orientation parameters (EOP) [kernel](https://naif.jpl.nasa.gov/pub/naif/generic_kernels/pck/earth_720101_070426_historical.bpc).
+This package ships the Navigation and Ancillary Information Facility's high accuracy, historical Earth orientation parameters (EOP) [kernel](https://naif.jpl.nasa.gov/pub/naif/generic_kernels/pck/earth_720101_230601.bpc).
 
 **This is not an official NAIF package**. It is an automatically generated mirror of the file so that it is
 installable via `pip`. 
 
-The current version of the file released on 2007 APR 27 spans the following times: 1972 JAN 01 00:00:42.183 - 2007 APR 26 00:01:05.185
+The current version of the file released on 2007 APR 27 spans the following times: 1972 JAN 01 00:00:42.183 - 2023 JUN 01 00:01:09.184
 
 ## Installation
 
-The latest version of the file can be install via pip:  
+The latest version of the file can be installed via pip:  
 `pip install naif-eop-historical`
 
 ## Usage

--- a/naif_eop_historical/__init__.py
+++ b/naif_eop_historical/__init__.py
@@ -1,4 +1,4 @@
 from importlib.resources import files
 
-eop_historical = files("naif_eop_historical").joinpath("earth_720101_070426.bpc").as_posix()
-_eop_historical_md5 = files("naif_eop_historical").joinpath("earth_720101_070426.md5").as_posix()
+eop_historical = files("naif_eop_historical").joinpath("earth_720101_230601.bpc").as_posix()
+_eop_historical_md5 = files("naif_eop_historical").joinpath("earth_720101_230601.md5").as_posix()

--- a/naif_eop_historical/fetch.py
+++ b/naif_eop_historical/fetch.py
@@ -4,9 +4,9 @@ import os
 
 import requests
 
-URL = "https://naif.jpl.nasa.gov/pub/naif/generic_kernels/pck/earth_720101_070426.bpc"
-FILE = os.path.join(os.path.dirname(__file__), "earth_720101_070426.bpc")
-MD5_FILE = os.path.join(os.path.dirname(__file__), "earth_720101_070426.md5")
+URL = "https://naif.jpl.nasa.gov/pub/naif/generic_kernels/pck/earth_720101_230601.bpc"
+FILE = os.path.join(os.path.dirname(__file__), "earth_720101_230601.bpc")
+MD5_FILE = os.path.join(os.path.dirname(__file__), "earth_720101_230601.md5")
 
 
 def fetch_file(url: str, output_file: str):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "naif_eop_historical"
-version = "2007.04.27" 
+version = "2023.06.03" 
 authors = [
     {name = "B612 Asteroid Institute", email = "info@b612foundation.org"},
 ]
@@ -22,4 +22,4 @@ tests = [
 include-package-data = true
 
 [tool.setuptools.package-data]
-naif_eop_historical = ["naif_eop_historical/earth_720101_070426.bpc", "naif_eop_historical/earth_720101_070426.md5"]
+naif_eop_historical = ["naif_eop_historical/earth_720101_230601.bpc", "naif_eop_historical/earth_720101_230601.md5"]


### PR DESCRIPTION
Adds a daily workflow run to make sure we detect upstream file changes sooner. Since these files are only released every few years, running a compare upstream-like scenario seems unnecessary. 